### PR TITLE
Catch up with current mubi.com site

### DIFF
--- a/resources/lib/mubi.py
+++ b/resources/lib/mubi.py
@@ -9,13 +9,16 @@ from collections import namedtuple
 from BeautifulSoup import BeautifulSoup as BS
 
 Film      = namedtuple('Film', ['title', 'mubi_id', 'artwork', 'metadata'])
-Metadata  = namedtuple('Metadata', ['director', 'year', 'duration', 'country', 'plotoutline', 'plot'])
+Metadata  = namedtuple('Metadata', ['title', 'director', 'year', 'duration', 'country', 'plotoutline', 'plot', 'overlay'])
 
 class Mubi(object):
     _URL_MUBI         = "http://mubi.com"
     _URL_MUBI_SECURE  = "https://mubi.com"
     _USER_AGENT       = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2"
-    _regexps = { "watch_page":  re.compile(r"^.*/watch$")
+    _regexps = {
+	            "watch_page":  re.compile(r"^.*/watch$"),
+                "image_url":  re.compile(r"\((.*)\)"),
+                "country_year":  re.compile(r"(.*)\, ([0-9]{4})")
                }
     _mubi_urls = {
                   "login":      urljoin(_URL_MUBI_SECURE, "login"),
@@ -49,52 +52,67 @@ class Mubi(object):
                            
         self._logger.debug("Logging in as user '%s', auth token is '%s'" % (username, auth_token))
         
-        landing_page = self._session.post(self._mubi_urls["session"], data=session_payload)
-        self._userid = BS(landing_page.content).find("a", "link -image").get("href").split("/")[-1]
-
-        self._logger.debug("Login succesful, user ID is '%s'" % self._userid)
+        r = self._session.post(self._mubi_urls["session"], data=session_payload)
+        if r.status_code == 302:
+            self._logger.debug("Login succesful")
+        else:
+            self._logger.error("Login failed")
 
     def now_showing(self):
-        #<ol class="list-now-showing">
-        # <li class="film-tile film-media item -item-1">
-        #    <img class="film-thumb" src="***w856/the-idiots.jpg***">
-        #    <div class="film-tile-inner">
-        #        <a href="/films/the-idiots" class="film-link">
-        #            <div class="film-title">***The Idiots***</div>
-        #            <div class="director-year">***Lars von Trier, 1998***</div>
-        #        </a>
-        #        <a class="app-play-film play-film" data-filmid="***423***" href="/films/the-idiots/prescreen"></a>
-        #    </div>
-        #    <div class="now-showing-time-remaining">
-        #        <strong>**34h 30m**</strong>left
-        #    </div>
-        # </li>
-        #<ol>
         page = self._session.get(self._mubi_urls["nowshowing"])
         films = []
-        items = [x for x in BS(page.content).findAll("li", {"itemtype": "http://schema.org/Movie"})]
+        items = [x for x in BS(page.content).findAll("article")]
         for x in items:
 
             # core 
             mubi_id   = x.find('a', {"data-filmid": True}).get("data-filmid")
-            title     = x.find('span', {"itemprop": "name"}).text
-            artwork   = x.find('img', {"itemprop": "image"}).get("src")
-            
+            title     = x.find('h1').text
+
+            meta = x.find('h2');
+
             # director
-            director = x.find("div", {"class": "director-year"}).text
+            director = meta.find('a', {"itemprop": "director"}).parent.text
+
+            # country-year
+            country_year = meta.find('span', {"class": "full-width-tile__year-country light-on-dark"}).text
+            cyMatch = self._regexps["country_year"].match(country_year)
+            if cyMatch:
+                country = cyMatch.group(1)
+                year = cyMatch.group(2)
+            else:
+                country = None
+                year = None
+
+			# artwork
+            artStyle = x.find('div', {"style": True}).get("style")
+            urlMatch = self._regexps["image_url"].search(artStyle)
+            if urlMatch:
+                artwork = urlMatch.group(1)
+            else:
+                artwork = None
 
             # format a title with the year included for list_view
-			#listview_title = u'{0} ({1})'.format(title, year)
+            #listview_title = u'{0} ({1})'.format(title, year)
             listview_title = title
+
+            synopsis = x.find('p').text
+
+            if x.find('i', {"aria-label": "HD"}):
+                hd = True
+                listview_title = title + " [HD]"
+            else:
+                hd = False
 
             # metadata - ideally need to scrape this from the film page or a JSON API
             metadata = Metadata(
+                title=title, 
                 director=director, 
-                year=None, 
+                year=year, 
                 duration=None, 
-                country=None, 
-                plotoutline='Synopsis (not yet implemented)',
-                plot=""
+                country=country, 
+                plotoutline="",
+                plot=synopsis,
+                overlay=6 if hd else 0
             )
 
             f = Film(listview_title, mubi_id, artwork, metadata)


### PR DESCRIPTION
Besides the catch-up, I added detection of HD vs SD content. Since this plug-in only plays HD videos in SD, I think it's important to show which videos could be played in HD instead using a different client. I tried to add 'overlay: 6' to metadata, which should cover it AFAIK, but it doesn't work, maybe due to a limitation in xbmcswift2? So in addition to the overlay, I added " [HD]" to list view title of the movie, and added another attribute to meta-data for the clean title.

Known bugs with this version that I was too lazy to fix:
- Multiple directors are shown without space between them: Andrew Gray,Adam Gray (this is mubi.com bug also, but could be fixed)
- Special mark-up in synopsis is not handled and will show up as garbage
