### PR TITLE
Update 2017 03

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -26,6 +26,7 @@ def index():
 
 @plugin.route('/play/<identifier>')
 def play_film(identifier):
+    mubi.enable_film(identifier)
     return plugin.set_resolved_url(mubi.get_play_url(identifier))
 
 

--- a/addon.py
+++ b/addon.py
@@ -27,7 +27,8 @@ def index():
 @plugin.route('/play/<identifier>')
 def play_film(identifier):
     mubi.enable_film(identifier)
-    return plugin.set_resolved_url(mubi.get_play_url(identifier))
+    mubi_url = mubi.get_play_url(identifier)
+    return plugin.set_resolved_url(mubi_url)
 
 
 if __name__ == '__main__':

--- a/resources/lib/mubi.py
+++ b/resources/lib/mubi.py
@@ -122,26 +122,11 @@ class Mubi(object):
             films.append(f)
         return films
 
-    def is_film_available(self, name):
+    def enable_film(self, name):
         # Sometimes we have to load a prescreen page first before we can retrieve the film's secure URL
         # ie. https://mubi.com/films/lets-get-lost/prescreen --> https://mubi.com/films/lets-get-lost/watch
         self._session.head(self._mubi_urls["prescreen"] % name, allow_redirects=True)
-        return True
-
-        #if not self._session.get(self._mubi_urls["video"] % name):
-        #    prescreen_page = self._session.head(self._mubi_urls["prescreen"] % name, allow_redirects=True)
-        #    if not prescreen_page:
-        #        raise Exception("Oops, something went wrong while scraping :(")
-        #    elif self._regexps["watch_page"].match(prescreen_page.url):
-        #        return True
-        #    else:
-        #        availability = BS(prescreen_page.content).find("div", "film_viewable_status ").text
-        #        return not "Not Available to watch" in availability
-        #else:
-        #    return True
 
     def get_play_url(self, name):
-        if not self.is_film_available(name):
-            raise Exception("This film is not available.")
         return self._session.get(self._mubi_urls["video"] % name).content
 

--- a/resources/lib/mubi.py
+++ b/resources/lib/mubi.py
@@ -90,15 +90,11 @@ class Mubi(object):
             else:
                 artwork = None
 
-            # format a title with the year included for list_view
-            #listview_title = u'{0} ({1})'.format(title, year)
-            listview_title = title
 
             synopsis = x.find('p').text
 
             if x.find('i', {"aria-label": "HD"}):
                 hd = True
-                listview_title = title + " [HD]"
             else:
                 hd = False
 
@@ -113,6 +109,12 @@ class Mubi(object):
                 plot=synopsis,
                 overlay=6 if hd else 0
             )
+
+            # format a title with the year included for list_view
+            #listview_title = u'{0} ({1})'.format(title, year)
+            listview_title = title
+            if hd:
+                listview_title += " [HD]"
 
             f = Film(listview_title, mubi_id, artwork, metadata)
 

--- a/resources/lib/mubi.py
+++ b/resources/lib/mubi.py
@@ -15,7 +15,6 @@ class Mubi(object):
     _URL_MUBI         = "https://mubi.com"
     _USER_AGENT       = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2"
     _regexps = {
-        "watch_page":  re.compile(r"^.*/watch$"),
         "image_url":  re.compile(r"\((.*)\)"),
         "country_year":  re.compile(r"(.*)\, ([0-9]{4})")
     }

--- a/resources/lib/mubi.py
+++ b/resources/lib/mubi.py
@@ -90,8 +90,9 @@ class Mubi(object):
             else:
                 artwork = None
 
+            plotoutline = x.find('p').text
 
-            synopsis = x.find('p').text
+            plot = "" # TODO: access film page to read the full plot
 
             if x.find('i', {"aria-label": "HD"}):
                 hd = True
@@ -105,8 +106,8 @@ class Mubi(object):
                 year=year,
                 duration=None,
                 country=country,
-                plotoutline="",
-                plot=synopsis,
+                plotoutline=plotoutline,
+                plot=plot,
                 overlay=6 if hd else 0
             )
 

--- a/resources/lib/mubi.py
+++ b/resources/lib/mubi.py
@@ -12,8 +12,7 @@ Film      = namedtuple('Film', ['title', 'mubi_id', 'artwork', 'metadata'])
 Metadata  = namedtuple('Metadata', ['title', 'director', 'year', 'duration', 'country', 'plotoutline', 'plot', 'overlay'])
 
 class Mubi(object):
-    _URL_MUBI         = "http://mubi.com"
-    _URL_MUBI_SECURE  = "https://mubi.com"
+    _URL_MUBI         = "https://mubi.com"
     _USER_AGENT       = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2"
     _regexps = {
         "watch_page":  re.compile(r"^.*/watch$"),
@@ -21,8 +20,8 @@ class Mubi(object):
         "country_year":  re.compile(r"(.*)\, ([0-9]{4})")
     }
     _mubi_urls = {
-        "login":      urljoin(_URL_MUBI_SECURE, "login"),
-        "session":    urljoin(_URL_MUBI_SECURE, "session"),
+        "login":      urljoin(_URL_MUBI, "login"),
+        "session":    urljoin(_URL_MUBI, "session"),
         "nowshowing": urljoin(_URL_MUBI, "films/showing"),
         "video":      urljoin(_URL_MUBI, "films/%s/secure_url"),
         "prescreen":  urljoin(_URL_MUBI, "films/%s/watch"),


### PR DESCRIPTION
An update to the scraper code to make the plugin compatible with the current Mubi website.

The new code will properly inspect the pages and find the correct "secure url". That address points to a playlist in DASH/M3U (depends on the movie). In theory these playlists are supported by Kodi 17+ but I could not get them to work. Somebody with more knowledge than me will make them work in few minutes I hope.

@jamieu: why did you squash the previous PR? Squashing commits makes merges unnecessarily more complex.