### PR TITLE
API call updates & support of DRM playback

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -1,8 +1,15 @@
-from kodiswift import xbmc, Plugin, ListItem
+from __future__ import absolute_import, division, unicode_literals
+from kodiswift import xbmc, Plugin, ListItem, xbmcgui
 from resources.lib.mubi import Mubi
+import xbmcplugin
 
 PLUGIN_NAME = 'MUBI'
 PLUGIN_ID = 'plugin.video.mubi'
+
+DRM = 'widevine'
+PROTOCOL = 'mpd'
+LICENSE_URL = 'https://lic.drmtoday.com/license-proxy-widevine/cenc/'
+LICENSE_URL_HEADERS = 'User-Agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.123 Safari/537.36&Host=lic.drmtoday.com&Origin=https://mubi.com&Referer=https://mubi.com/&Sec-Fetch-Dest=empty&Sec-Fetch-Mode=cors&Sec-Fetch-Site=cross-site&Accept-Encoding=gzip, deflate, br&Accept-Language=en-US,en;q=0.9&Connection=keep-alive&Content-Type=application/json;charset=utf-8'
 
 plugin = Plugin(PLUGIN_NAME, PLUGIN_ID, __file__)
 
@@ -28,18 +35,21 @@ def index():
 @plugin.route('/play/<identifier>')
 def play_film(identifier):
     mubi_resolved_info = mubi.get_play_url(identifier)
-    mubi_film = ListItem(path=mubi_resolved_info['url'])
+    mubi_film = xbmcgui.ListItem(path=mubi_resolved_info['url'])
+
     if mubi_resolved_info['is_mpd']:
-        mubi_film.set_property('inputstreamaddon', 'inputstream.adaptive')
-        mubi_film.set_property('inputstream.adaptive.manifest_type', 'mpd')
+        mubi_film.setProperty('inputstreamaddon', 'inputstream.adaptive')
+        mubi_film.setProperty('inputstream.adaptive.manifest_type', 'mpd')
+
         if mubi_resolved_info['is_drm']:
-            xbmc.log("Playing DRM films is not currently supported", 4)
-            return None
-            # drm = mubi_resolved_info['drm_item']
-            # mubi_film.set_property('inputstream.adaptive.license_key', drm['lurl']+'|'+drm['header']+
-            # '|B{SSM}|'+drm['license_field'])
-            # mubi_film.set_property('inputstream.adaptive.license_type', "com.widevine.alpha")
-    return plugin.set_resolved_url(mubi_film)
+            xbmc.log('DRM Header: %s' %mubi_resolved_info['drm_header'], 2)
+            mubi_film.setProperty('inputstream.adaptive.license_type', "com.widevine.alpha")
+            mubi_film.setProperty('inputstream.adaptive.license_key', LICENSE_URL + '|' + LICENSE_URL_HEADERS + '&dt-custom-data=' + mubi_resolved_info['drm_header'] + '|R{SSM}|JBlicense')
+            mubi_film.setMimeType('application/dash+xml')
+            mubi_film.setContentLookup(False)
+    return xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, listitem=mubi_film)
+
+    #return plugin
 
 
 if __name__ == '__main__':

--- a/addon.xml
+++ b/addon.xml
@@ -2,6 +2,7 @@
 <addon id="plugin.video.mubi" name="MUBI" version="0.8" provider-name="Jamie Unwin">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
+    <import addon="script.module.inputstreamhelper" version="0.4.5"/>
     <import addon="script.module.kodiswift" version="0.0.8"/>
     <import addon="script.module.requests" version="2.12.4"/>
     <import addon="script.module.dateutil" version="2.5.3"/>


### PR DESCRIPTION
Forgive potential dirty hacks and inconsistent code, I have never worked on Kodi addons in particular and python projects in general.

I reverse-engineered the Android app and found that API calls are now usually routed to `https://mobi.com/api/v1/[...]` (instead of `/services/android/[...]` like before, although some of the old routes apparently still work and, hence, have not been updated by me yet). It is important to send the relevant header fields like `client`, `client-app` etc.

DRM licenses are issued by `https://lic.drmtoday.com/license-proxy-widevine/cenc/`. Here, too, it is important to send all the header fields that could be found by reverse-engineering the API calls.

In particular, the field `dt-custom-data` has to be sent. This field contains a base64-encoded string including the following data:
`{"userId":[userId],"sessionId":"[sessionToken]","merchant":"mubi"}`

For DRM playback support, inputstream.adaptive and Widevine have to be installed, [e.g. following this instructions](https://www.matthuisman.nz/2018/05/kodi-widevine-support.html). 